### PR TITLE
making qubit and qubit_def storage and types consistent + other cleanups

### DIFF
--- a/grammar_definitions/guppy.bnf
+++ b/grammar_definitions/guppy.bnf
@@ -16,7 +16,7 @@ block_def   = "@guppy" NEWLINE "def " circuit_name LPAREN block_args RPAREN " ->
 
 block_args  = qubit_defs_external; # TODO: Add additional traditional parameters in future
 
-qubit_defs_external =   qubit_def_external (COMMA qubit_def_external)*;
+qubit_defs_external = EMPTY | qubit_def_external (COMMA qubit_def_external)*;
 
 qubit_defs_internal =   (qubit_def_internal NEWLINE)*; # 0 or more since there could be 0 internal qubit definitions
 

--- a/include/ast_builder/ast.h
+++ b/include/ast_builder/ast.h
@@ -25,7 +25,7 @@ class Ast{
 
         std::shared_ptr<Node> get_node_from_term(const Term& term);
 
-        Result<Node, std::string> build();
+        Result<Node> build();
 
         virtual void ast_to_program(fs::path output_dir, const std::string& extension, int num_programs);
 

--- a/include/ast_builder/context.h
+++ b/include/ast_builder/context.h
@@ -5,6 +5,7 @@
 #include <qubit_definition.h>
 #include <graph.h>
 #include <variable.h>
+#include <qubit_defs.h>
 
 class Gate;
 
@@ -40,7 +41,7 @@ namespace Context {
 
             std::shared_ptr<Block> setup_block(std::string str, U64 hash);
             
-			size_t make_qubit_definitions(bool external = true);
+			std::shared_ptr<Qubit_defs> make_qubit_definitions(std::string& str, U64& hash);
 
 			std::shared_ptr<Block> get_block(std::string owner);
 

--- a/include/ast_builder/qubit.h
+++ b/include/ast_builder/qubit.h
@@ -7,33 +7,34 @@
 namespace Qubit {
 
     enum Type {
-        REGISTER,
-        SINGULAR
+        REGISTER_EXTERNAL,
+        REGISTER_INTERNAL,
+        SINGULAR_EXTERNAL,
+        SINGULAR_INTERNAL
     };
 
     class Qubit : public Node {
         public:
 
+            /// @brief Dummy qubit
             Qubit() :
                 Node("qubit", hash_rule_name("qubit")),
                 value(Singular_qubit()),
-                type(SINGULAR)
-            {
+                type(SINGULAR_EXTERNAL)
+            {}
 
-            }
-
-            Qubit(Register_qubit qubit) :
+            Qubit(Register_qubit qubit, bool external) :
                 Node("qubit", hash_rule_name("qubit")),
                 value(qubit),
-                type(REGISTER)
+                type(external ? REGISTER_EXTERNAL : REGISTER_INTERNAL)
             {
                 constraint = std::make_optional<Size_constraint>(Common::register_qubit, 1);
             }
 
-            Qubit(Singular_qubit qubit) :
+            Qubit(Singular_qubit qubit, bool external) :
                 Node("qubit", hash_rule_name("qubit")),
                 value(qubit),
-                type(SINGULAR)
+                type(external ? SINGULAR_EXTERNAL : SINGULAR_INTERNAL)
             {
                 constraint = std::make_optional<Size_constraint>(Common::singular_qubit, 1);
             }
@@ -66,8 +67,16 @@ namespace Qubit {
                 }, value);
             }
 
+            inline bool is_external() const {
+                return ((type == REGISTER_EXTERNAL) || (type == SINGULAR_EXTERNAL));
+            }
+
+            inline bool is_register_def() const {
+                return ((type == REGISTER_EXTERNAL) || (type == REGISTER_INTERNAL));
+            }
+
             inline std::shared_ptr<Integer> get_index(){
-                if(type == REGISTER){
+                if(is_register_def()){
                     return std::get<Register_qubit>(value).get_index();
                 }
 
@@ -78,7 +87,7 @@ namespace Qubit {
 
             inline std::string resolved_name(){
 
-                if(type == REGISTER){
+                if(is_register_def()){
                     return get_name()->get_string() + "_" + get_index()->get_string();
                 } else {
                     return get_name()->get_string();
@@ -90,8 +99,6 @@ namespace Qubit {
             std::variant<Register_qubit, Singular_qubit> value;
             Type type;
     };
-
-
 
 }
 

--- a/include/ast_builder/qubit_definition.h
+++ b/include/ast_builder/qubit_definition.h
@@ -17,6 +17,7 @@ namespace Qubit_definition {
 
         public:
 
+            /// @brief Dummy definition
             Qubit_definition() : 
                 Node("qubit_def", hash_rule_name("qubit_def")),
                 value(Register_qubit_definition()), 

--- a/include/ast_builder/qubit_defs.h
+++ b/include/ast_builder/qubit_defs.h
@@ -7,7 +7,7 @@ class Qubit_defs : public Node {
 
     public:
 
-        Qubit_defs(std::string str, U64 hash, int num_defs, bool external = true):
+        Qubit_defs(std::string str, U64 hash, size_t num_defs, bool external):
             Node(str, hash, indentation_tracker)
         {
             if(external){

--- a/include/ast_builder/register_qubit_definition.h
+++ b/include/ast_builder/register_qubit_definition.h
@@ -5,6 +5,7 @@
 #include <register_qubit.h>
 #include <variable.h>
 #include <integer.h>
+#include <collection.h>
 
 class Register_qubit_definition : public Node {
 
@@ -31,13 +32,13 @@ class Register_qubit_definition : public Node {
 
         /// @brief Add qubits to the given vector from the qreg
         /// @param qubits 
-        void make_qubits(std::vector<Qubit::Qubit>& block_qubits) const {
+        void make_qubits(Collection<Qubit::Qubit>& output, bool external) const {
             size_t reg_size = safe_stoi(size.get_string()).value();
 
             for(size_t i = 0; i < reg_size; i++){
                 Register_qubit reg_qubit(name, Integer(std::to_string(i)));
 
-                block_qubits.push_back(Qubit::Qubit(reg_qubit));
+                output.add(Qubit::Qubit(reg_qubit, external));
             }
         }
 

--- a/include/ast_builder/singular_qubit_definition.h
+++ b/include/ast_builder/singular_qubit_definition.h
@@ -21,9 +21,9 @@ class Singular_qubit_definition : public Node {
             return std::make_shared<Variable>(name);
         }
 
-        void make_qubits(std::vector<Qubit::Qubit>& block_qubits) const {
+        void make_qubits(Collection<Qubit::Qubit>& output, bool external) const {
             Singular_qubit singular_qubit(name);
-            block_qubits.push_back(Qubit::Qubit(singular_qubit));
+            output.add(Qubit::Qubit(singular_qubit, external));
         }
 
     private:

--- a/include/grammar_parser/grammar.h
+++ b/include/grammar_parser/grammar.h
@@ -107,8 +107,8 @@ class Grammar{
         std::vector<Token::Token> tokens;
         size_t num_tokens = 0;
         size_t token_pointer = 0;
-        Result<Token::Token, std::string> curr_token;
-        Result<Token::Token, std::string> next_token;
+        Result<Token::Token> curr_token;
+        Result<Token::Token> next_token;
         Token::Token prev_token;
 
         std::string range_start = "", range_end = "";

--- a/include/grammar_parser/lex.h
+++ b/include/grammar_parser/lex.h
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <fstream>
 
-#include <utils.h>
+#include <result.h>
 
 namespace Token {
     enum Token_kind {
@@ -145,7 +145,7 @@ namespace Lexer {
             }
 
         private:
-            Result<std::vector<Token::Token>, std::string> result;
+            Result<std::vector<Token::Token>> result;
             std::string _filename = "bnf.bnf"; 
             bool ignore = false;
             

--- a/include/utils/collection.h
+++ b/include/utils/collection.h
@@ -1,0 +1,62 @@
+#ifndef COLLECTION_H
+#define COLLECTION_H
+
+#include <qubit.h>
+
+template<typename T>
+struct Collection {
+
+    public:
+
+        Collection(){}
+
+        void add(const T& elem){
+            if(elem.is_external()){
+                num_external += 1;
+            } else {
+                num_internal += 1;
+            }
+
+            coll.push_back(elem);
+        }
+
+        T* at(size_t index) {
+            if(index < get_total()){
+                return &coll.at(index); 
+
+            } else {
+                return nullptr;
+            
+            }
+        }
+
+        size_t get_num_internal() const {
+            return num_internal;
+        }
+
+        size_t get_num_external() const {
+            return num_external;
+        }
+
+        size_t get_total() const {
+            return coll.size();
+        }
+
+        void reset(){
+            if constexpr (std::is_same_v<T, Qubit::Qubit>){
+                for(Qubit::Qubit& qb : coll){
+                    qb.reset();
+                }
+            }
+        }
+
+    private:
+    
+        std::vector<T> coll = {};
+        size_t num_internal = 0;
+        size_t num_external = 0;
+
+};
+
+
+#endif

--- a/include/utils/qubit_combinations.h
+++ b/include/utils/qubit_combinations.h
@@ -1,0 +1,58 @@
+#ifndef QUBIT_COMBS_H
+#define QUBIT_COMBS_H
+
+#include <utils.h>
+
+struct Qubit_combinations{
+    public:
+        void set(int num_qubits, int num_qubits_in_entanglement, std::vector<std::vector<int>>& entanglements){
+            data[num_qubits-1][num_qubits_in_entanglement-1] = entanglements;
+        }
+
+        std::vector<std::vector<int>> at(int num_qubits, int num_qubits_in_entanglement) const {
+            return data[num_qubits-1][num_qubits_in_entanglement-1];
+        }
+
+        void set_possible_qubit_combinations(){
+
+            for(int n_qubits = Common::MIN_N_QUBITS_IN_ENTANGLEMENT; n_qubits <= Common::MAX_QUBITS; n_qubits++){
+                for(int n_qubits_in_entanglement = Common::MIN_N_QUBITS_IN_ENTANGLEMENT; n_qubits_in_entanglement <= n_qubits; n_qubits_in_entanglement++){
+                    std::vector<std::vector<int>> combs = n_choose_r(n_qubits, n_qubits_in_entanglement);
+                    set(n_qubits, n_qubits_in_entanglement, combs);
+                }
+            }
+
+            #if 0
+            std::cout << QUBIT_COMBINATIONS << std::endl;
+            #endif
+        }
+
+        friend std::ostream& operator<<(std::ostream& stream, Qubit_combinations& combs){
+
+            for(int n_qubits = Common::MIN_N_QUBITS_IN_ENTANGLEMENT; n_qubits <= Common::MAX_QUBITS; n_qubits++){
+
+                stream << "N qubits: " << n_qubits << std::endl;
+                stream << "==================================" << std::endl;
+
+                for(int n_qubits_in_entanglement = Common::MIN_N_QUBITS_IN_ENTANGLEMENT; n_qubits_in_entanglement <= n_qubits; n_qubits_in_entanglement++){
+                    
+                    stream << "n_qubits_in_entanglement: " << n_qubits_in_entanglement << std::endl;
+
+                    for(const std::vector<int>& entanglement : combs.at(n_qubits, n_qubits_in_entanglement)){
+                        for(const int& i : entanglement) std::cout << i << " ";
+                        stream << " ";
+                    }
+                    stream << std::endl;
+                }
+            }
+
+            return stream;
+        }
+
+    private:
+        std::vector<std::vector<int>> data[Common::MAX_QUBITS][Common::MAX_QUBITS];
+};
+
+extern Qubit_combinations QUBIT_COMBINATIONS;
+
+#endif

--- a/include/utils/result.h
+++ b/include/utils/result.h
@@ -1,0 +1,53 @@
+#ifndef RESULT_H
+#define RESULT_H
+
+#include <utils.h>
+
+/*
+    inspired by F# ;)
+*/
+
+template<typename T>
+struct Result{
+
+    public:
+        Result(){}
+
+        ~Result(){}
+
+        void set_ok(T val){
+            as = val;
+        }
+
+        void set_error(const std::string& err){
+            as = err;
+        }
+
+        T get_ok() const {
+            if(is_ok()){return std::get<T>(as);}
+            else {
+                throw std::runtime_error(ANNOT("get_ok called on error!"));
+            }
+        }
+
+        std::string get_error() const {
+            if(is_error()){return std::get<std::string>(as);}
+            else {
+                throw std::runtime_error(ANNOT("get_error called on OK!"));
+            }
+        }
+
+        bool is_ok() const {
+            return std::holds_alternative<T>(as);
+        }
+
+        bool is_error() const {
+            return std::holds_alternative<std::string>(as);
+        }
+
+    private:
+        std::variant<T, std::string> as;
+};
+
+
+#endif

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -52,8 +52,6 @@ std::optional<int> safe_stoi(const std::string& str);
 
 std::vector<std::vector<int>> n_choose_r(const int n, const int r);
 
-void set_possible_qubit_combinations();
-
 int vector_sum(std::vector<int> in);
 
 int vector_max(std::vector<int> in);
@@ -65,53 +63,15 @@ std::string pipe_from_command(std::string command);
 std::string escape(const std::string& str);
 
 namespace Common {
-    constexpr char TOP_LEVEL_CIRCUIT_NAME[] = "main";
+    constexpr char TOP_LEVEL_CIRCUIT_NAME[] = "main_circuit";
     constexpr int MIN_N_QUBITS_IN_ENTANGLEMENT = 2;
-    constexpr int MIN_QUBITS = 3; 
-    constexpr int MAX_QUBITS = std::max(MIN_QUBITS + 1, (int)(0.4 * WILDCARD_MAX));
-    constexpr int MAX_SUBROUTINES = (0.2 * WILDCARD_MAX);
+    constexpr int MIN_QUBITS = 3;
+    constexpr int MAX_QUBITS = std::max(MIN_QUBITS + 1, (int)(0.5 * WILDCARD_MAX));
+    constexpr int MAX_SUBROUTINES = (int)(0.5 * WILDCARD_MAX);
 
     extern bool plot;
     extern bool verbose; 
-
-    struct Qubit_combinations{
-        public:
-            void set(int num_qubits, int num_qubits_in_entanglement, std::vector<std::vector<int>>& entanglements){
-                data[num_qubits-1][num_qubits_in_entanglement-1] = entanglements;
-            }
-
-            std::vector<std::vector<int>> at(int num_qubits, int num_qubits_in_entanglement) const {
-                return data[num_qubits-1][num_qubits_in_entanglement-1];
-            }
-
-            friend std::ostream& operator<<(std::ostream& stream, Qubit_combinations& combs){
-
-                for(int n_qubits = Common::MIN_N_QUBITS_IN_ENTANGLEMENT; n_qubits <= Common::MAX_QUBITS; n_qubits++){
-
-                    stream << "N qubits: " << n_qubits << std::endl;
-                    stream << "==================================" << std::endl;
-
-                    for(int n_qubits_in_entanglement = Common::MIN_N_QUBITS_IN_ENTANGLEMENT; n_qubits_in_entanglement <= n_qubits; n_qubits_in_entanglement++){
-                        
-                        stream << "n_qubits_in_entanglement: " << n_qubits_in_entanglement << std::endl;
-
-                        for(const std::vector<int>& entanglement : combs.at(n_qubits, n_qubits_in_entanglement)){
-                            for(const int& i : entanglement) std::cout << i << " ";
-                            stream << " ";
-                        }
-                        stream << std::endl;
-                    }
-                }
-
-                return stream;
-            }
-
-        private:
-            std::vector<std::vector<int>> data[MAX_QUBITS][MAX_QUBITS];
-    };
-
-    extern Qubit_combinations QUBIT_COMBINATIONS;
-
+    
     enum Rule_hash : U64 {
         // SINGLE QUBIT GATES
         h = 12638197096160295895ULL,
@@ -203,70 +163,6 @@ namespace Common {
         indent = 8881161079555216635ULL,
         dedent = 2224769550356995471ULL,
     };
-}
-
-template<typename A, typename B>
-struct Result{
-
-    public:
-        Result(){}
-
-        ~Result(){}
-
-        void set_ok(A a){
-            as = a;
-        }
-
-        void set_error(B b){
-            as = b;
-        }
-
-        A get_ok() const {
-            if(is_ok()){return std::get<A>(as);}
-            else {
-                throw std::runtime_error(ANNOT("get_ok called on error!"));
-            }
-        }
-
-        B get_error() const {
-            if(is_error()){return std::get<B>(as);}
-            else {
-                throw std::runtime_error(ANNOT("get_error called on OK!"));
-            }
-        }
-
-        bool is_ok() const {
-            return as.index() == 0;
-        }
-
-        bool is_error() const {
-            return as.index() == 1;
-        }
-
-    private:
-        std::variant<A, B> as;
-};
-
-template<typename T>
-std::vector<T> multiply_vector(std::vector<T> vec, int mult){
-    std::vector<T> multiplied_vec;
-    
-    multiplied_vec.reserve(vec.size() * mult);
-
-    for(int i = 0; i < mult; ++i){
-        multiplied_vec.insert(multiplied_vec.end(), vec.begin(), vec.end());
-    }
-
-    return multiplied_vec;
-}
-
-template<typename T>
-std::vector<T> append_vectors(std::vector<T> vec1, std::vector<T> vec2){
-    std::vector<T> result = vec1;
-
-    result.insert(result.end(), vec2.begin(), vec2.end());
-
-    return result;
 }
 
 #endif

--- a/src/ast_builder/ast.cpp
+++ b/src/ast_builder/ast.cpp
@@ -1,5 +1,6 @@
 #include <ast.h>
 
+#include <result.h>
 #include <block.h>
 #include <gate.h>
 #include <compound_stmts.h>
@@ -93,15 +94,8 @@ std::shared_ptr<Node> Ast::get_node_from_term(const Term& term){
 			case Common::qubit_def_external: case Common::qubit_def_internal:
 				return context.get_current_qubit_definition();
 
-			case Common::qubit_defs_external: {
-				size_t num_qubit_definitions = context.make_qubit_definitions();
-				return std::make_shared<Qubit_defs>(str, hash, num_qubit_definitions);
-			}
-
-			case Common::qubit_defs_internal: {
-				size_t num_qubit_definitions = context.make_qubit_definitions(false);
-				return std::make_shared<Qubit_defs>(str, hash, num_qubit_definitions, false);
-			}
+			case Common::qubit_defs_external: case Common::qubit_defs_internal:
+				return context.make_qubit_definitions(str, hash);
 
 			case Common::qubit_list: {
 				size_t num_qubits = context.get_current_gate_num_qubits();
@@ -178,8 +172,8 @@ void Ast::write_branch(std::shared_ptr<Node> parent, const Term& term){
 	parent->transition_to_done();
 }
 
-Result<Node, std::string> Ast::build(){
-	Result<Node, std::string> res;
+Result<Node> Ast::build(){
+	Result<Node> res;
 
 	if(entry == nullptr){
 		res.set_error("Entry point not set");
@@ -208,7 +202,7 @@ void Ast::ast_to_program(fs::path output_dir, const std::string& extension, int 
 
 		context.set_circuits_dir(current_circuit_dir);
 		
-	    Result<Node, std::string> maybe_ast_root = build();
+	    Result<Node> maybe_ast_root = build();
 
 		if(maybe_ast_root.is_ok()){
 			Node ast_root = maybe_ast_root.get_ok();
@@ -222,7 +216,7 @@ void Ast::ast_to_program(fs::path output_dir, const std::string& extension, int 
 			INFO("Program written to " + program_path.string());
 			
 			// render AST
-			render_ast(ast_root, current_circuit_dir);
+			// render_ast(ast_root, current_circuit_dir);
 
 			// render QIG for main
 			context.render_qig();

--- a/src/ast_builder/context.cpp
+++ b/src/ast_builder/context.cpp
@@ -76,31 +76,33 @@ namespace Context {
 
     std::shared_ptr<Block> Context::setup_block(std::string str, U64 hash){
 
-        int target_num_qubits;
+        int target_num_qubits_external;
 
         if(current_block_is_subroutine()){
             current_block_owner = "sub"+std::to_string(subroutine_counter++);
-            target_num_qubits = random_int(Common::MAX_QUBITS, Common::MIN_QUBITS);
+            target_num_qubits_external = random_int(Common::MAX_QUBITS, Common::MIN_QUBITS);
 
         } else {
             current_block_owner = Common::TOP_LEVEL_CIRCUIT_NAME;
-            target_num_qubits = get_max_defined_qubits();
+            target_num_qubits_external = get_max_defined_qubits();
 
             subroutine_counter = 0;
         }
 
-        std::shared_ptr<Block> current_block = std::make_shared<Block>(str, hash, current_block_owner, target_num_qubits);
+        std::shared_ptr<Block> current_block = std::make_shared<Block>(str, hash, current_block_owner, target_num_qubits_external);
         blocks.push_back(current_block);
 
         return current_block;
     }
 
-    size_t Context::make_qubit_definitions(bool external){
+    std::shared_ptr<Qubit_defs> Context::make_qubit_definitions(std::string& str, U64& hash){
         std::shared_ptr<Block> current_block = get_current_block();
 
-        current_block->make_qubit_definitions(external);
+        bool external = (hash == Common::qubit_defs_external);
 
-        return current_block->num_qubit_definitions(external);
+        size_t num_defs = current_block->make_qubit_definitions(external);
+
+        return std::make_shared<Qubit_defs>(str, hash, num_defs, external);
     }
 
     std::shared_ptr<Block> Context::get_block(std::string owner){
@@ -201,6 +203,6 @@ namespace Context {
 
     void Context::set_qig(){
         render_qig();
-        qig = std::make_shared<Graph>(current_block_owner, get_current_block()->num_external_qubits());
+        qig = std::make_shared<Graph>(current_block_owner, get_current_block()->total_num_qubits());
     }
 }

--- a/src/grammar_parser/grammar.cpp
+++ b/src/grammar_parser/grammar.cpp
@@ -1,5 +1,27 @@
 #include <grammar.h>
 
+template<typename T>
+std::vector<T> multiply_vector(std::vector<T> vec, int mult){
+    std::vector<T> multiplied_vec;
+    
+    multiplied_vec.reserve(vec.size() * mult);
+
+    for(int i = 0; i < mult; ++i){
+        multiplied_vec.insert(multiplied_vec.end(), vec.begin(), vec.end());
+    }
+
+    return multiplied_vec;
+}
+
+template<typename T>
+std::vector<T> append_vectors(std::vector<T> vec1, std::vector<T> vec2){
+    std::vector<T> result = vec1;
+
+    result.insert(result.end(), vec2.begin(), vec2.end());
+
+    return result;
+}
+
 Grammar::Grammar(const fs::path& filename): lexer(filename.string()), name(filename.stem()), path(filename) {
     // lexer.print_tokens();
 

--- a/src/qig/graph.cpp
+++ b/src/qig/graph.cpp
@@ -1,4 +1,5 @@
 #include <graph.h>
+#include <qubit_combinations.h>
 
 std::vector<int> Graph::djikstras(int source_node){
 
@@ -87,8 +88,8 @@ std::optional<std::vector<int>> Graph::get_best_entanglement(int n_qubits_in_ent
 
         int best_score = -INT32_MAX;
 
-        std::vector<std::vector<int>> possible_entanglements = Common::QUBIT_COMBINATIONS.at(vertices, n_qubits_in_entanglement);
-        std::vector<std::vector<int>> edges = Common::QUBIT_COMBINATIONS.at(n_qubits_in_entanglement, 2); 
+        std::vector<std::vector<int>> possible_entanglements = QUBIT_COMBINATIONS.at(vertices, n_qubits_in_entanglement);
+        std::vector<std::vector<int>> edges = QUBIT_COMBINATIONS.at(n_qubits_in_entanglement, 2); 
 
         std::vector<int> res = possible_entanglements[0];
 
@@ -124,8 +125,8 @@ void Graph::render_graph(fs::path& img_path, std::shared_ptr<Block> block){
     for (int i = 0; i < n; ++i){
         for (int j = i+1; j < n; ++j){
             if (graph[i][j]) {
-                std::string qubit_i = block->get_qubit_at(i)->resolved_name();
-                std::string qubit_j = block->get_qubit_at(j)->resolved_name();
+                std::string qubit_i = block->qubit_at(i)->resolved_name();
+                std::string qubit_j = block->qubit_at(j)->resolved_name();
 
                 dot_string += ("  " + qubit_i + " -- " + qubit_j + " [label=" + std::to_string(graph[i][j]) + ", color=\"red\", penwidth=3];\n");
             }

--- a/src/run.cpp
+++ b/src/run.cpp
@@ -1,5 +1,8 @@
 #include <run.h>
 #include <ast.h>
+#include <qubit_combinations.h>
+
+Qubit_combinations QUBIT_COMBINATIONS;
 
 void Program_Spec::setup_builder(const std::string entry_name){
     if(grammar->is_rule(entry_name)){
@@ -67,7 +70,8 @@ Run::Run(const std::string& _grammars_dir) : grammars_dir(_grammars_dir) {
             }
 
         }
-        set_possible_qubit_combinations();
+
+        QUBIT_COMBINATIONS.set_possible_qubit_combinations();
 
     } catch (const fs::filesystem_error& error) {
         std::cout << error.what() << std::endl;

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -1,7 +1,6 @@
 #include <utils.h>
 
 namespace Common {
-    Qubit_combinations QUBIT_COMBINATIONS;
     bool plot = false;
     bool verbose = false; 
 }
@@ -131,19 +130,6 @@ int vector_max(std::vector<int> in){
     return max;
 }
 
-void set_possible_qubit_combinations(){
-
-    for(int n_qubits = Common::MIN_N_QUBITS_IN_ENTANGLEMENT; n_qubits <= Common::MAX_QUBITS; n_qubits++){
-        for(int n_qubits_in_entanglement = Common::MIN_N_QUBITS_IN_ENTANGLEMENT; n_qubits_in_entanglement <= n_qubits; n_qubits_in_entanglement++){
-            std::vector<std::vector<int>> combs = n_choose_r(n_qubits, n_qubits_in_entanglement);
-            Common::QUBIT_COMBINATIONS.set(n_qubits, n_qubits_in_entanglement, combs);
-        }
-    }
-
-    #if 0
-    std::cout << Common::QUBIT_COMBINATIONS << std::endl;
-    #endif
-}
 
 void pipe_to_command(std::string command, std::string write){
     FILE* pipe = popen(command.c_str(), "w");


### PR DESCRIPTION
- this PR aligns qubit def and qubit storage, giving them types depending on whether they're defined externally or internally, then storing each in one buffer
- other cleanups