### PR TITLE
maybe better segfault fix and other cleanups

### DIFF
--- a/include/ast_builder/block.h
+++ b/include/ast_builder/block.h
@@ -18,7 +18,9 @@ class Block : public Node {
         Block(std::string str, U64 hash, std::string owner_name, int _target_num_qubits_external) : 
             Node(str, hash),
             owner(owner_name), 
-            target_num_qubits_external(_target_num_qubits_external) {}
+            target_num_qubits_external(_target_num_qubits_external),
+            target_num_qubits_internal(random_int(Common::MAX_QUBITS, target_num_qubits_external) - target_num_qubits_external)
+        {}
 
         inline bool owned_by(std::string other){return other == owner;}
 
@@ -69,7 +71,7 @@ class Block : public Node {
     private:
         std::string owner;
         int target_num_qubits_external = Common::MIN_QUBITS;
-        int target_num_qubits_internal = random_int(Common::MAX_QUBITS, Common::MIN_QUBITS);
+        int target_num_qubits_internal = Common::MAX_QUBITS - Common::MIN_QUBITS;
         
         bool can_apply_subroutines = false;
 

--- a/include/qig/graph.h
+++ b/include/qig/graph.h
@@ -6,9 +6,13 @@
 #include <fstream>
 #include <limits>
 
+struct Qubit_combinations;
+
 class Graph {
 
     public:
+        static const Qubit_combinations qubit_combinations;
+
         Graph(){}
 
         Graph(std::string _owner, int _vertices) :
@@ -16,12 +20,7 @@ class Graph {
         vertices(_vertices), 
         num_pairs((vertices * (vertices - 1)) / 2),
         graph(vertices, std::vector<int>(vertices, 0)), 
-        shortest_distances(vertices, std::vector<int>(vertices, 0)){
-//             if(vertices < Common::MIN_N_QUBITS_IN_ENTANGLEMENT){
-//                 
-            //     // throw std::runtime_error(ANNOT("Num vertices in graph < " + std::to_string(Common::MIN_N_QUBITS_IN_ENTANGLEMENT)));
-            // }
-        }
+        shortest_distances(vertices, std::vector<int>(vertices, 0)){}
 
         inline std::string get_owner(){return owner;}
 

--- a/include/utils/collection.h
+++ b/include/utils/collection.h
@@ -39,7 +39,7 @@ struct Collection {
         }
 
         size_t get_total() const {
-            return coll.size();
+            return num_internal + num_external;
         }
 
         void reset(){

--- a/include/utils/qubit_combinations.h
+++ b/include/utils/qubit_combinations.h
@@ -4,9 +4,14 @@
 #include <utils.h>
 
 struct Qubit_combinations{
+    
     public:
-        void set(int num_qubits, int num_qubits_in_entanglement, std::vector<std::vector<int>>& entanglements){
-            data[num_qubits-1][num_qubits_in_entanglement-1] = entanglements;
+        Qubit_combinations(){
+            set_possible_qubit_combinations();
+        }
+
+        void set(int num_qubits, int num_qubits_in_entanglement, std::vector<std::vector<int>> entanglements){
+            data[num_qubits-1][num_qubits_in_entanglement-1] = std::move(entanglements);
         }
 
         std::vector<std::vector<int>> at(int num_qubits, int num_qubits_in_entanglement) const {
@@ -17,14 +22,10 @@ struct Qubit_combinations{
 
             for(int n_qubits = Common::MIN_N_QUBITS_IN_ENTANGLEMENT; n_qubits <= Common::MAX_QUBITS; n_qubits++){
                 for(int n_qubits_in_entanglement = Common::MIN_N_QUBITS_IN_ENTANGLEMENT; n_qubits_in_entanglement <= n_qubits; n_qubits_in_entanglement++){
-                    std::vector<std::vector<int>> combs = n_choose_r(n_qubits, n_qubits_in_entanglement);
-                    set(n_qubits, n_qubits_in_entanglement, combs);
+                    set(n_qubits, n_qubits_in_entanglement, n_choose_r(n_qubits, n_qubits_in_entanglement));
                 }
             }
-
-            #if 0
-            std::cout << QUBIT_COMBINATIONS << std::endl;
-            #endif
+            
         }
 
         friend std::ostream& operator<<(std::ostream& stream, Qubit_combinations& combs){
@@ -52,7 +53,5 @@ struct Qubit_combinations{
     private:
         std::vector<std::vector<int>> data[Common::MAX_QUBITS][Common::MAX_QUBITS];
 };
-
-extern Qubit_combinations QUBIT_COMBINATIONS;
 
 #endif

--- a/src/ast_builder/context.cpp
+++ b/src/ast_builder/context.cpp
@@ -203,6 +203,11 @@ namespace Context {
 
     void Context::set_qig(){
         render_qig();
-        qig = std::make_shared<Graph>(current_block_owner, get_current_block()->total_num_qubits());
+
+        size_t total_num_qubits = get_current_block()->total_num_qubits();
+
+        INFO("Setting QIG for " + current_block_owner + " with " + std::to_string(total_num_qubits) + " qubits");
+        
+        qig = std::make_shared<Graph>(current_block_owner, total_num_qubits);
     }
 }

--- a/src/qig/graph.cpp
+++ b/src/qig/graph.cpp
@@ -1,6 +1,8 @@
 #include <graph.h>
 #include <qubit_combinations.h>
 
+const Qubit_combinations Graph::qubit_combinations;
+
 std::vector<int> Graph::djikstras(int source_node){
 
     std::vector<int> distances(vertices, __INT_MAX__);
@@ -36,14 +38,6 @@ std::vector<int> Graph::djikstras(int source_node){
             }
         }
     }
-
-    // // print distances
-
-    // for(size_t i = 0; i < vertices; ++i){
-    //     std::cout << distances[i] << " ";
-    // }
-
-    // std::cout << std::endl;
 
     return distances;
 }
@@ -84,14 +78,18 @@ int Graph::score(){
 }
 
 std::optional<std::vector<int>> Graph::get_best_entanglement(int n_qubits_in_entanglement){
-    if((n_qubits_in_entanglement >= Common::MIN_N_QUBITS_IN_ENTANGLEMENT) && (vertices >= Common::MIN_QUBITS)){
+    if ((n_qubits_in_entanglement >= Common::MIN_N_QUBITS_IN_ENTANGLEMENT) && 
+        (n_qubits_in_entanglement <= Common::MAX_QUBITS) && 
+        (vertices >= Common::MIN_QUBITS) && 
+        (vertices <= Common::MAX_QUBITS))
+    {
 
         int best_score = -INT32_MAX;
 
-        std::vector<std::vector<int>> possible_entanglements = QUBIT_COMBINATIONS.at(vertices, n_qubits_in_entanglement);
-        std::vector<std::vector<int>> edges = QUBIT_COMBINATIONS.at(n_qubits_in_entanglement, 2); 
+        std::vector<std::vector<int>> possible_entanglements = qubit_combinations.at(vertices, n_qubits_in_entanglement);
+        std::vector<std::vector<int>> edges = qubit_combinations.at(n_qubits_in_entanglement, 2); 
 
-        std::vector<int> res = possible_entanglements[0];
+        std::vector<int> res;
 
         for(const std::vector<int>& entanglement : possible_entanglements){
             add_entanglement(entanglement, edges);

--- a/src/run.cpp
+++ b/src/run.cpp
@@ -2,7 +2,6 @@
 #include <ast.h>
 #include <qubit_combinations.h>
 
-Qubit_combinations QUBIT_COMBINATIONS;
 
 void Program_Spec::setup_builder(const std::string entry_name){
     if(grammar->is_rule(entry_name)){
@@ -70,8 +69,6 @@ Run::Run(const std::string& _grammars_dir) : grammars_dir(_grammars_dir) {
             }
 
         }
-
-        QUBIT_COMBINATIONS.set_possible_qubit_combinations();
 
     } catch (const fs::filesystem_error& error) {
         std::cout << error.what() << std::endl;

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -104,6 +104,7 @@ std::vector<std::vector<int>> n_choose_r(const int n, const int r){
         } while(std::prev_permutation(bitmask.begin(), bitmask.end()));
 
         return res;
+
     } else {
         throw std::runtime_error(ANNOT("n must be less than r, and r must be >= " + std::to_string(Common::MIN_N_QUBITS_IN_ENTANGLEMENT)));
     }


### PR DESCRIPTION
fix: running guppy would segfault. choosing internal and external qubit targets as before would create a situation where the total number of qubits = vertices in the QIG is larger than MAX_QUBITS, which is a problem, because qubit combinations setup only goes up to MAX_QUBITS. So trying to find combinations would result in accessing garbage memory.

I've taken a look at your fix which is to have the setup run for `2 * MAX_QUBITS`. While this works, IMO, it would be better to have one constant which we can point to and be absolutely sure that any block that gets generated has at most that many qubits, and that one constant controls everything else, instead of having magic numbers. In order to achieve this, we have to ensure that external and internal qubit targets are chosen such that the sum is always <= MAX_QUBITS, which I've done by 

```C++
Block(std::string str, U64 hash, std::string owner_name, int _target_num_qubits_external) : 
    Node(str, hash),
    owner(owner_name), 
    target_num_qubits_external(_target_num_qubits_external),
    target_num_qubits_internal(random_int(Common::MAX_QUBITS, target_num_qubits_external) - target_num_qubits_external)
{}
``` 

In the `Block` node.

This PR also contains some stronger checks before grabbing a set of possible combinations, as well as cleaner setup of those combinations.