### PR TITLE
control flow beginnings

### DIFF
--- a/grammar_definitions/guppy.bnf
+++ b/grammar_definitions/guppy.bnf
@@ -10,7 +10,7 @@ main_block_def = decorators NEWLINE "def " circuit_name LPAREN RPAREN " -> None"
 
 block       = block_def NEWLINE INDENT body discard_internal_qubits simple_stmt DEDENT NEWLINE;
 
-body   = qubit_defs_internal compound_stmts ;
+body   = qubit_defs_internal compound_stmts;
 
 compound_stmts = (compound_stmt NEWLINE)*;
 
@@ -22,7 +22,7 @@ decorators = "@guppy"
 
 block_args  = qubit_defs_external; # TODO: Add additional traditional parameters in future
 
-qubit_defs_external = EMPTY | qubit_def_external (COMMA qubit_def_external)*;
+qubit_defs_external = | qubit_def_external (COMMA qubit_def_external)*;
 
 qubit_defs_internal =   (qubit_def_internal NEWLINE)*; # 0 or more since there could be 0 internal qubit definitions
 
@@ -39,7 +39,40 @@ singular_qubit_def_internal = qubit_name EQUALS "qubit" LPAREN RPAREN;
 register_qubit_def_internal = qreg_name EQUALS "array" LPAREN "qubit() for _ in range" LPAREN qreg_size RPAREN RPAREN;
 # register_qubit_def_internal = qreg_name EQUALS LBRACK "qubit() for _ in range" LPAREN qreg_size RPAREN RBRACK;    # For comptime only
 
-compound_stmt = qubit_op;
+compound_stmt = qubit_op | if_stmt;
+
+if_stmt =
+    # | 'if' expression ':' NEWLINE INDENT compound_stmts elif_block DEDENT;
+    | 'if' expression ':' NEWLINE INDENT compound_stmts DEDENT (else_block)?;
+elif_block =
+    | 'elif' expression ':' NEWLINE INDENT compound_stmts DEDENT elif_block
+    | 'elif' expression ':' NEWLINE INDENT compound_stmts DEDENT (else_block)?;
+else_block =
+    | 'else' ':' NEWLINE INDENT compound_stmts DEDENT;
+
+expressions =
+    expression (',' expression )+
+    | expression ','
+    | expression;
+
+expression =
+    disjunction;
+
+disjunction =
+    conjunction ('or' conjunction )+
+    | conjunction;
+
+conjunction =
+    inversion ('and' inversion )+ 
+    | inversion;
+
+inversion =
+    # 'not' inversion
+    comparison;
+
+comparison = " True "
+    | " False "
+    ;
 
 qubit_op  = gate_op
             | subroutine_op;

--- a/grammar_definitions/testbed.bnf
+++ b/grammar_definitions/testbed.bnf
@@ -3,3 +3,6 @@
 # factor = integer | "(" expr ")" ;
 # ret = "q" "there";
 # integer = 1-4;
+
+mt = 
+    | "test";

--- a/include/ast_builder/ast.h
+++ b/include/ast_builder/ast.h
@@ -23,7 +23,7 @@ class Ast{
 
         void write_branch(std::shared_ptr<Node> parent, const Term& term);
 
-        std::shared_ptr<Node> get_node_from_term(const Term& term);
+        std::shared_ptr<Node> get_node_from_term(const std::shared_ptr<Node> parent, const Term& term);
 
         Result<Node> build();
 

--- a/include/ast_builder/compound_stmt.h
+++ b/include/ast_builder/compound_stmt.h
@@ -1,0 +1,22 @@
+#ifndef COMPOUND_STMT_H
+#define COMPOUND_STMT_H
+
+#include <node.h>
+
+class Compound_stmt : public Node {
+
+    public:
+
+        Compound_stmt(std::string str, U64 hash, int compound_stmt_depth):
+            Node(str, hash, indentation_tracker)
+        {
+            if(compound_stmt_depth == 0){
+                constraint = std::make_optional<Size_constraint>(Common::qubit_op, 1);
+            }
+        }
+
+    private:
+
+};
+
+#endif

--- a/include/ast_builder/context.h
+++ b/include/ast_builder/context.h
@@ -8,13 +8,15 @@
 #include <qubit_defs.h>
 #include <discard_qubit_defs.h>
 #include <discard_qubit_def.h>
+#include <compound_stmt.h>
+#include <gate.h>
 
-class Gate;
 
 namespace Context {
 
     enum Level {
         PROGRAM,
+		BLOCK,
         QUBIT_OP,
     };
 
@@ -55,15 +57,19 @@ namespace Context {
 
 			std::shared_ptr<Qubit_definition::Qubit_definition> get_current_qubit_definition();
 
-			std::shared_ptr<Discard_qubit_def> get_current_qubit_definition_discard(std::string str, U64 hash);
+			std::shared_ptr<Discard_qubit_def> get_current_qubit_definition_discard(const std::string& str, const U64& hash);
 
 			std::shared_ptr<Integer> get_current_qubit_definition_size();
 
 			std::shared_ptr<Variable> get_current_qubit_definition_name();
 
-			std::shared_ptr<Gate> get_current_gate(std::string str, int num_qubits, int num_params);
+			std::shared_ptr<Gate> get_current_gate(const std::string& str, int num_qubits, int num_params);
 
-			std::shared_ptr<Discard_qubit_defs> discard_qubit_defs(std::string str, U64 hash, int num_owned_qubit_defs);
+			std::shared_ptr<Discard_qubit_defs> discard_qubit_defs(const std::string& str, const U64& hash, int num_owned_qubit_defs);
+
+			std::shared_ptr<Node> get_control_flow_stmt(const std::string& str, const U64& hash);
+
+			std::shared_ptr<Compound_stmt> get_compound_stmt(const std::string& str, const U64& hash);
 
 			int get_current_gate_num_params();
 
@@ -98,6 +104,8 @@ namespace Context {
 			std::shared_ptr<Qubit::Qubit> current_qubit;
 			std::shared_ptr<Gate> current_gate;
 			std::shared_ptr<Node> subroutines_node = nullptr;
+
+	        size_t compound_stmt_depth = Common::COMPOUND_STMT_DEPTH;
     };
 
 }

--- a/include/ast_builder/qubit_op.h
+++ b/include/ast_builder/qubit_op.h
@@ -8,7 +8,7 @@ class Qubit_op : public Node {
     public:
 
         Qubit_op(std::string str, U64 hash, bool can_use_subroutine):
-            Node(str, hash, indentation_tracker)
+            Node(str, hash)
         {
             if(can_use_subroutine == false){
                 constraint = std::make_optional<Size_constraint>(Common::subroutine_op, 0);

--- a/include/grammar_parser/grammar.h
+++ b/include/grammar_parser/grammar.h
@@ -29,15 +29,21 @@ class Grammar{
         inline void reset_current_branches(){current_branches.clear();}
         
         inline void add_current_branches_to_rule(){
-            // add all current branches to current rule, reset current branches
-            for(Branch& current_branch : current_branches){
-                #if 0
-                std::cout << "Lazily adding ";
-                current_branch.print(std::cout);
-                std::cout << std::endl;
-                #endif
 
-                current_rule->add(current_branch);
+            if(current_branches.size() == 0){
+                current_rule->add(Branch());
+                
+            } else {
+
+                for(Branch& current_branch : current_branches){
+                    #if 0
+                    std::cout << "Lazily adding ";
+                    current_branch.print(std::cout);
+                    std::cout << std::endl;
+                    #endif
+
+                    current_rule->add(current_branch);
+                }
             }
         }
 

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -19,7 +19,7 @@
 #include <array>
 #include <iomanip>
 
-#define WILDCARD_MAX 20
+#define WILDCARD_MAX 5
 
 #define UNUSED(x) (void)(x)
 
@@ -68,6 +68,7 @@ namespace Common {
     constexpr int MIN_QUBITS = 3;
     constexpr int MAX_QUBITS = std::max(MIN_QUBITS + 1, (int)(0.5 * WILDCARD_MAX));
     constexpr int MAX_SUBROUTINES = (int)(0.5 * WILDCARD_MAX);
+    constexpr int COMPOUND_STMT_DEPTH = 5;
 
     extern bool plot;
     extern bool verbose; 
@@ -169,6 +170,8 @@ namespace Common {
         
         indent = 8881161079555216635ULL,
         dedent = 2224769550356995471ULL,
+
+        if_stmt = 5300980200188049869ULL,
     };
 }
 


### PR DESCRIPTION
- Added grammar for control flow in guppy
- Just if statements

### Todos
- Indentation for else and elif not quite working. Probably need a better indentation algorithm
- May be worth limiting the number of `disjunction` nodes 