### PR TITLE
Benny quantinuum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ RUN apt update && apt install -y \
     gdb \
     && apt clean && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install pytket qiskit pytket-qiskit matplotlib sympy z3-solver pytket-quantinuum cirq guppylang --break-system-packages
+RUN python3 -m pip install pytket qiskit pytket-qiskit matplotlib sympy z3-solver pytket-quantinuum cirq --break-system-packages
+
+# Install latest guppylang from main branch on GitHub
+RUN python3 -m pip install git+https://github.com/CQCL/guppylang.git@main --break-system-packages
 
 WORKDIR /qutefuzz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt update && apt install -y \
     gdb \
     && apt clean && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install pytket qiskit pytket-qiskit matplotlib sympy z3-solver pytket-quantinuum cirq --break-system-packages
+RUN python3 -m pip install pytket qiskit pytket-qiskit matplotlib sympy z3-solver cirq pytket-quantinuum[pecos] --break-system-packages
 
 # Install latest guppylang from main branch on GitHub
 RUN python3 -m pip install git+https://github.com/CQCL/guppylang.git@main --break-system-packages

--- a/diff_testing/lib.py
+++ b/diff_testing/lib.py
@@ -31,9 +31,9 @@ import shutil
 # Pytket imports
 from pytket.circuit import Circuit
 from pytket.passes import *
-from pytket.extensions.qiskit import AerBackend
-from pytket.extensions.qiskit import AerStateBackend
-from pytket.extensions.quantinuum import QuantinuumBackend
+# from pytket.extensions.qiskit import AerBackend
+# from pytket.extensions.qiskit import AerStateBackend
+from pytket.extensions.quantinuum import QuantinuumBackend, QuantinuumAPIOffline
 
 # Qiskit imports
 from qiskit import QuantumCircuit, transpile
@@ -86,7 +86,7 @@ class Base():
 
         assert (len(sample1) == total_shots) and (len(sample2) == total_shots), "Sample size does not match number of shots"
 
-        ks_stat, p_value = ks_2samp(sorted(sample1), sorted(sample2))
+        ks_stat, p_value = ks_2samp(sorted(sample1), sorted(sample2), method='asymp')
 
         return p_value
     
@@ -125,7 +125,10 @@ class pytketTesting(Base):
         '''
         Runs circuit on pytket simulator and returns counts
         '''
-        backend = AerBackend()
+        # Pytket Quantinuum backend
+        api_offline = QuantinuumAPIOffline()
+        backend = QuantinuumBackend(device_name="H1-1LE", api_handler=api_offline)
+
         # Get original circuit shots
         uncompiled_circ = backend.get_compiled_circuit(circuit, optimisation_level=0)
         handle1 = backend.process_circuit(uncompiled_circ, n_shots=1000)

--- a/diff_testing/lib.py
+++ b/diff_testing/lib.py
@@ -27,6 +27,7 @@ import matplotlib.ticker as ticker
 import traceback
 import pathlib
 import shutil
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 
 # Pytket imports
 from pytket.circuit import Circuit
@@ -46,7 +47,7 @@ enable_experimental_features()
 
 class Base():
     # Define the plots directory as a class variable
-    OUTPUT_DIR = (pathlib.Path(__file__).parent.parent.parent / "outputs").resolve()
+    OUTPUT_DIR = (pathlib.Path(__file__).parent.parent / "outputs").resolve()
 
     def __init__(self):
         super().__init__()
@@ -93,6 +94,27 @@ class Base():
     def compare_statevectors(self, sv1 : NDArray[np.complex128], sv2 : NDArray[np.complex128]):
         return np.dot(sv1, sv2)
 
+    def save_interesting_circuit(self, circuit_number: int, interesting_dir: pathlib.Path) -> None:
+        '''
+        Saves an interesting circuit file to the specified directory
+        '''
+        # Ensure the interesting directory exists
+        interesting_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Define source and destination paths
+        circuit_source_path = self.OUTPUT_DIR / f"circuit{circuit_number}" / "circuit.py"
+        circuit_dest_path = interesting_dir / f"circuit{circuit_number}.py"
+        
+        # Check if source file exists and copy it
+        if circuit_source_path.exists():
+            try:
+                shutil.copy2(circuit_source_path, circuit_dest_path)
+                print(f"Circuit file saved to: {circuit_dest_path}")
+            except Exception as e:
+                print(f"Error copying circuit file: {e}")
+        else:
+            print(f"Warning: Circuit file not found at {circuit_source_path}")
+
     def plot_histogram(self, res : Counter[int, int], title : str, compilation_level : int, circuit_number : int = 0):
         # Check the number of existing plots in plots_path (if exists), then increment the number of the plot
         # and save the plot with that number
@@ -121,7 +143,7 @@ class pytketTesting(Base):
     def __init__(self):
         super().__init__()
     
-    def run_circ(self, circuit : Circuit, circuit_number : int) -> float:
+    def run_circ(self, circuit : Circuit, circuit_number : int) -> None:
         '''
         Runs circuit on pytket simulator and returns counts
         '''
@@ -129,31 +151,48 @@ class pytketTesting(Base):
         api_offline = QuantinuumAPIOffline()
         backend = QuantinuumBackend(device_name="H1-1LE", api_handler=api_offline)
 
-        # Get original circuit shots
-        uncompiled_circ = backend.get_compiled_circuit(circuit, optimisation_level=0)
-        handle1 = backend.process_circuit(uncompiled_circ, n_shots=1000)
-        result1 = backend.get_result(handle1)
-        counts1 = self.preprocess_counts(result1.get_counts())
+        try:
+            # Get original circuit shots
+            uncompiled_circ = backend.get_compiled_circuit(circuit, optimisation_level=0)
+            handle1 = backend.process_circuit(uncompiled_circ, n_shots=1000)
+            result1 = backend.get_result(handle1)
+            counts1 = self.preprocess_counts(result1.get_counts())
+            is_testcase_interesting = False
+            consistency_counter = 0
 
-        # Compile circuit at 3 different optimisation levels
-        for i in range(3):
-            compiled_circ = backend.get_compiled_circuit(circuit, optimisation_level=i+1)
-        
-            # Process the compiled circuit
-            handle2 = backend.process_circuit(compiled_circ, n_shots=1000)
-            result2 = backend.get_result(handle2)
-            counts2 = self.preprocess_counts(result2.get_counts())
+            # Compile circuit at 3 different optimisation levels
+            for i in range(3):
+                compiled_circ = backend.get_compiled_circuit(circuit, optimisation_level=i+1)
+            
+                # Process the compiled circuit
+                handle2 = backend.process_circuit(compiled_circ, n_shots=1000)
+                result2 = backend.get_result(handle2)
+                counts2 = self.preprocess_counts(result2.get_counts())
 
-            # Run the kstest on the two results
-            ks_value = self.ks_test(counts1, counts2, 1000)
-            print(f"Optimisation level {i+1} ks-test p-value: {ks_value}")
+                # Run the kstest on the two results
+                ks_value = self.ks_test(counts1, counts2, 1000)
+                print(f"Optimisation level {i+1} ks-test p-value: {ks_value}")
 
-            # plot results
-            if self.plot:
-                self.plot_histogram(counts1, "Uncompiled Circuit Results", 0, circuit_number)
-                self.plot_histogram(counts2, "Compiled Circuit Results", i+1, circuit_number)
+                # Heuristic to determine if the testcase is interesting
+                if ks_value < 0.2 :
+                    consistency_counter += 1
+                if ks_value < 0.05 or consistency_counter >= 2:
+                    is_testcase_interesting = True
+                
+                # plot results
+                if self.plot:
+                    self.plot_histogram(counts1, "Uncompiled Circuit Results", 0, circuit_number)
+                    self.plot_histogram(counts2, "Compiled Circuit Results", i+1, circuit_number)
 
-        return ks_value
+        except Exception as e:
+            print("Exception :", traceback.format_exc())
+            is_testcase_interesting = True
+
+        # Dump files to a "interesting circuits" folder if found interesting testcase
+        if is_testcase_interesting:
+            print(f"Interesting circuit found: {circuit_number}")
+            interesting_dir = self.OUTPUT_DIR / "interesting_circuits"
+            self.save_interesting_circuit(circuit_number, interesting_dir)
     
     def run_circ_statevector(self, circuit : Circuit, test_pass : BasePass ) -> NDArray[np.complex128]:
         '''
@@ -225,13 +264,32 @@ class guppyTesting(Base):
     def __init__(self):
         super().__init__()
 
-    def run_circ(self, circuit : Any, circuit_number : int) -> float:
+    def run_circ(self, circuit : Any, circuit_number : int) -> None:
         '''
-        Compiles and runs guppy program on simulator and returns counts
+        Compiles guppy circuit
         '''
-        guppy.compile(circuit)
+        is_testcase_interesting = False
+        timeout_seconds = 60
+        
+        def compile_circuit():
+            return guppy.compile(circuit)
+        
+        # Run the compile with timeout using ThreadPoolExecutor
+        try:
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(compile_circuit)
+                result = future.result(timeout=timeout_seconds)
+                
+        except FuturesTimeoutError:
+            print(f"Compilation timed out after {timeout_seconds} seconds")
+            is_testcase_interesting = True
+        except Exception as e:
+            print("Error during compilation:", e)
+            is_testcase_interesting = True
 
-if __name__ == "__main__":
-    b = Base()
-    b.plot_histogram({1 : 10, 2 : 20})
+        # Dump files to a "interesting circuits" folder if found interesting testcase
+        if is_testcase_interesting:
+            print(f"Interesting circuit found: {circuit_number}")
+            interesting_dir = self.OUTPUT_DIR / "interesting_circuits"
+            self.save_interesting_circuit(circuit_number, interesting_dir)
 

--- a/grammar_definitions/guppy.bnf
+++ b/grammar_definitions/guppy.bnf
@@ -31,14 +31,14 @@ qubit_defs_internal =   (qubit_def_internal NEWLINE)*;
 qubit_def_external  = singular_qubit_def_external
                     | register_qubit_def_external;
 
-singular_qubit_def_external = qreg_name COLON "qubit";
-register_qubit_def_external = qreg_name COLON "array" LBRACK "qubit" COMMA qreg_size RBRACK;
+singular_qubit_def_external = qubit_def_name COLON "qubit";
+register_qubit_def_external = qubit_def_name COLON "array" LBRACK "qubit" COMMA qreg_size RBRACK;
 
 qubit_def_internal = singular_qubit_def_internal
                     | register_qubit_def_internal;
 
-singular_qubit_def_internal = qreg_name EQUALS "qubit" LPAREN RPAREN;
-register_qubit_def_internal = qreg_name EQUALS "array" LPAREN "qubit() for _ in range" LPAREN qreg_size RPAREN RPAREN;
+singular_qubit_def_internal = qubit_def_name EQUALS "qubit" LPAREN RPAREN;
+register_qubit_def_internal = qubit_def_name EQUALS "array" LPAREN "qubit() for _ in range" LPAREN qreg_size RPAREN RPAREN;
 
 compound_stmt = qubit_op ;
                 # | if_stmt;
@@ -157,8 +157,8 @@ discard_internal_qubits = (discard_internal_qubit NEWLINE)*;
 discard_internal_qubit = discard_single_qubit
                         | discard_qreg;
 
-discard_qreg = "discard_array" LPAREN qreg_name RPAREN;
-discard_single_qubit = "discard" LPAREN qreg_name RPAREN;
+discard_qreg = "discard_array" LPAREN qubit_def_name RPAREN;
+discard_single_qubit = "discard" LPAREN qubit_def_name RPAREN;
 
 gate_name = 
     x | y | z | h | cx | toffoli | rz | rx | ry

--- a/grammar_definitions/guppy.bnf
+++ b/grammar_definitions/guppy.bnf
@@ -29,17 +29,18 @@ qubit_defs_internal = (qubit_def_internal NEWLINE)*; # 0 or more since there cou
 qubit_def_external  = singular_qubit_def_external 
                     | register_qubit_def_external;
 
-singular_qubit_def_external = qubit_name COLON "qubit";
+singular_qubit_def_external = qreg_name COLON "qubit";
 register_qubit_def_external = qreg_name COLON "array" LBRACK "qubit" COMMA qreg_size RBRACK;
 
 qubit_def_internal = singular_qubit_def_internal
                     | register_qubit_def_internal;
 
-singular_qubit_def_internal = qubit_name EQUALS "qubit" LPAREN RPAREN;
+singular_qubit_def_internal = qreg_name EQUALS "qubit" LPAREN RPAREN;
 register_qubit_def_internal = qreg_name EQUALS "array" LPAREN "qubit() for _ in range" LPAREN qreg_size RPAREN RPAREN;
 # register_qubit_def_internal = qreg_name EQUALS LBRACK "qubit() for _ in range" LPAREN qreg_size RPAREN RBRACK;    # For comptime only
 
-compound_stmt = qubit_op | if_stmt;
+compound_stmt = qubit_op ;
+                # | if_stmt;
 
 if_stmt =
     'if' expression ':' NEWLINE INDENT compound_stmts DEDENT elif_stmt
@@ -146,7 +147,7 @@ discard_internal_qubit = discard_single_qubit
                         | discard_qreg;
 
 discard_qreg = "discard_array" LPAREN qreg_name RPAREN;
-discard_single_qubit = "discard" LPAREN qubit_name RPAREN;
+discard_single_qubit = "discard" LPAREN qreg_name RPAREN;
 
 gate_name = 
     x | y | z | h | cx | toffoli | rz | rx | ry

--- a/grammar_definitions/guppy.bnf
+++ b/grammar_definitions/guppy.bnf
@@ -28,7 +28,7 @@ qubit_defs_external = | qubit_def_external (COMMA qubit_def_external)*;
 
 qubit_defs_internal =   (qubit_def_internal NEWLINE)*;
 
-qubit_def_external  = singular_qubit_def_external;
+qubit_def_external  = singular_qubit_def_external
                     | register_qubit_def_external;
 
 singular_qubit_def_external = qreg_name COLON "qubit";

--- a/grammar_definitions/guppy.bnf
+++ b/grammar_definitions/guppy.bnf
@@ -132,7 +132,17 @@ qubit_op  = gate_op
             | subroutine_op;
 
 gate_op = gate_name gate_op_kind;
-subroutine_op = subroutine LPAREN qubit_list RPAREN;
+subroutine_op = subroutine LPAREN arguments RPAREN;
+
+# For function calls, arguments need to match definition (e.g. qubit, array of qubits, etc.) IN ORDER
+arguments = arg (COMMA arg)*;
+
+arg = arg_singular_qubit
+    | LBRACK arg_register_qubits RBRACK
+    ;
+
+arg_singular_qubit = qubit;
+arg_register_qubits = qubit (COMMA SPACE qubit)*;
 
 gate_op_kind =  LPAREN qubit_list RPAREN 
                 | LPAREN qubit_list COMMA float_list RPAREN

--- a/grammar_definitions/guppy.bnf
+++ b/grammar_definitions/guppy.bnf
@@ -4,29 +4,31 @@ program     = imports NEWLINE subroutines NEWLINE main_block NEWLINE compiler_ca
 
 subroutines = (block NEWLINE)*;
 
-# A main block in guppy is a special case, where it cannot contain external qubit defs or any qubits, but could contain regular inputs?
-main_block = main_block_def NEWLINE INDENT body discard_internal_qubits simple_stmt DEDENT NEWLINE;
-main_block_def = decorators NEWLINE "def " circuit_name LPAREN RPAREN " -> None" COLON;
+block = non_comptime_block
+        | comptime_block;
 
-block       = block_def NEWLINE INDENT body discard_internal_qubits simple_stmt DEDENT NEWLINE;
+# A main block in guppy is a special case, where it cannot contain external qubit defs or any qubits, but could contain regular inputs?
+# It also needs to be comptime to apply other subcircuits
+main_block = main_block_def NEWLINE INDENT body discard_internal_qubits simple_stmt DEDENT NEWLINE;
+main_block_def = "@guppy.comptime" NEWLINE "def " circuit_name LPAREN RPAREN " -> None" COLON;
+
+non_comptime_block = block_def NEWLINE INDENT body discard_internal_qubits simple_stmt DEDENT NEWLINE;
+block_def   = "@guppy" NEWLINE "def " circuit_name LPAREN block_args RPAREN " -> None" type COLON;
+
+comptime_block = comptime_block_def NEWLINE INDENT body discard_internal_qubits simple_stmt DEDENT NEWLINE;
+comptime_block_def =  "@guppy.comptime" NEWLINE "def " circuit_name LPAREN block_args RPAREN " -> None" type COLON;
 
 body   = qubit_defs_internal compound_stmts;
 
 compound_stmts = (compound_stmt NEWLINE)*;
 
-block_def   = decorators NEWLINE "def " circuit_name LPAREN block_args RPAREN " -> None" type COLON;
-
-decorators = "@guppy"
-            # | "@guppy.comptime"
-            ;
-
 block_args  = qubit_defs_external; # TODO: Add additional traditional parameters in future
 
 qubit_defs_external = | qubit_def_external (COMMA qubit_def_external)*;
 
-qubit_defs_internal = (qubit_def_internal NEWLINE)*; # 0 or more since there could be 0 internal qubit definitions
+qubit_defs_internal =   (qubit_def_internal NEWLINE)*;
 
-qubit_def_external  = singular_qubit_def_external 
+qubit_def_external  = singular_qubit_def_external;
                     | register_qubit_def_external;
 
 singular_qubit_def_external = qreg_name COLON "qubit";
@@ -37,7 +39,6 @@ qubit_def_internal = singular_qubit_def_internal
 
 singular_qubit_def_internal = qreg_name EQUALS "qubit" LPAREN RPAREN;
 register_qubit_def_internal = qreg_name EQUALS "array" LPAREN "qubit() for _ in range" LPAREN qreg_size RPAREN RPAREN;
-# register_qubit_def_internal = qreg_name EQUALS LBRACK "qubit() for _ in range" LPAREN qreg_size RPAREN RBRACK;    # For comptime only
 
 compound_stmt = qubit_op ;
                 # | if_stmt;
@@ -151,7 +152,7 @@ discard_single_qubit = "discard" LPAREN qreg_name RPAREN;
 
 gate_name = 
     x | y | z | h | cx | toffoli | rz | rx | ry
-    # | t | tdg | s | sdg | ch | crz 
+    | t | tdg | s | sdg | ch | crz 
     # | measure | measure_array | reset | project_z
     ;
 
@@ -170,4 +171,5 @@ imports = "from guppylang.decorator import guppy " NEWLINE
         "from diff_testing.lib import guppyTesting " NEWLINE
         "from pathlib import Path " NEWLINE;
 
-compiler_call = "guppyTesting.run_circ(main_circuit)" NEWLINE;
+compiler_call = "gt = guppyTesting()" NEWLINE
+                "gt.run_circ(main_circuit" COMMA circuit_id RPAREN NEWLINE;

--- a/grammar_definitions/pytket.bnf
+++ b/grammar_definitions/pytket.bnf
@@ -28,8 +28,8 @@ compound_stmts = (compound_stmt NEWLINE)+;
 qubit_def_external  = singular_qubit_def_external 
                     | register_qubit_def_external;
 
-singular_qubit_def_external = qreg_name EQUALS "Qubit" LPAREN DOUBLE_QUOTE qreg_name DOUBLE_QUOTE RPAREN NEWLINE circuit_name ".add_qubit" LPAREN qreg_name RPAREN;
-register_qubit_def_external =  qreg_name EQUALS circuit_name ".add_q_register" LPAREN '"' qreg_name '",' qreg_size RPAREN;
+singular_qubit_def_external = qubit_def_name EQUALS "Qubit" LPAREN DOUBLE_QUOTE qubit_def_name DOUBLE_QUOTE RPAREN NEWLINE circuit_name ".add_qubit" LPAREN qubit_def_name RPAREN;
+register_qubit_def_external =  qubit_def_name EQUALS circuit_name ".add_q_register" LPAREN '"' qubit_def_name '",' qreg_size RPAREN;
 
 compound_stmt = qubit_op;
 

--- a/grammar_definitions/pytket.bnf
+++ b/grammar_definitions/pytket.bnf
@@ -28,6 +28,7 @@ compound_stmts = (compound_stmt NEWLINE)+;
 qubit_def_external  = singular_qubit_def_external 
                     | register_qubit_def_external;
 
+singular_qubit_def_external = qreg_name EQUALS circuit_name ".add_qubit" LPAREN "Qubit" LPAREN DOUBLE_QUOTE qreg_name DOUBLE_QUOTE RPAREN RPAREN;
 register_qubit_def_external =  qreg_name EQUALS circuit_name ".add_q_register" LPAREN '"' qreg_name '",' qreg_size RPAREN;
 
 compound_stmt = qubit_op;

--- a/grammar_definitions/pytket.bnf
+++ b/grammar_definitions/pytket.bnf
@@ -28,7 +28,7 @@ compound_stmts = (compound_stmt NEWLINE)+;
 qubit_def_external  = singular_qubit_def_external 
                     | register_qubit_def_external;
 
-singular_qubit_def_external = qreg_name EQUALS circuit_name ".add_qubit" LPAREN "Qubit" LPAREN DOUBLE_QUOTE qreg_name DOUBLE_QUOTE RPAREN RPAREN;
+singular_qubit_def_external = qreg_name EQUALS "Qubit" LPAREN DOUBLE_QUOTE qreg_name DOUBLE_QUOTE RPAREN NEWLINE circuit_name ".add_qubit" LPAREN qreg_name RPAREN;
 register_qubit_def_external =  qreg_name EQUALS circuit_name ".add_q_register" LPAREN '"' qreg_name '",' qreg_size RPAREN;
 
 compound_stmt = qubit_op;

--- a/include/ast_builder/arg.h
+++ b/include/ast_builder/arg.h
@@ -1,0 +1,44 @@
+#ifndef ARG_H
+#define ARG_H
+
+#include <node.h>
+
+namespace Arg {
+
+    enum Type {
+        SINGULAR,
+        REGISTER,
+        //INTEGER,
+        //FLOAT,
+    };
+
+    class Arg : public Node {
+        public:
+
+            /// @brief Dummy argument
+            Arg() :
+                Node("arg", hash_rule_name("arg")),
+                type(SINGULAR)
+            {
+                constraint = std::make_optional<Size_constraint>(Common::qubit, 1);
+            }
+
+            Arg(const std::string& str, const U64& hash, Type _type) :
+                Node(str, hash),
+                type(_type)
+            {
+                if (type == SINGULAR) {
+                    constraint = std::make_optional<Size_constraint>(Common::arg_singular_qubit, 1);
+                } else if (type == REGISTER) {
+                    constraint = std::make_optional<Size_constraint>(Common::arg_register_qubits, 1);
+                }
+            }
+            
+        private:
+            Type type;
+
+    };
+
+}
+
+#endif

--- a/include/ast_builder/arguments.h
+++ b/include/ast_builder/arguments.h
@@ -1,0 +1,20 @@
+#ifndef ARGUMENTS_H
+#define ARGUMENTS_H
+
+#include <node.h>
+
+class Arguments : public Node {
+
+    public:
+
+        Arguments(std::string str, U64 hash, int num_arguments):
+            Node(str, hash)
+        {
+            constraint = std::make_optional<Size_constraint>(Common::arg, num_arguments);
+        }
+
+    private:
+
+};
+
+#endif

--- a/include/ast_builder/block.h
+++ b/include/ast_builder/block.h
@@ -73,6 +73,8 @@ class Block : public Node {
 
         std::shared_ptr<Qubit_definition::Qubit_definition> get_next_owned_qubit_def();
 
+        std::shared_ptr<Qubit_definition::Qubit_definition> get_next_external_qubit_def();
+
         std::shared_ptr<Qubit::Qubit> get_random_qubit(std::optional<std::vector<int>> best_entanglement);
         
         size_t make_register_qubit_definition(int max_size, bool external);

--- a/include/ast_builder/block.h
+++ b/include/ast_builder/block.h
@@ -86,7 +86,7 @@ class Block : public Node {
         int target_num_qubits_external = Common::MIN_QUBITS;
         int target_num_qubits_internal = 0;
         
-        bool can_apply_subroutines = false;
+        bool can_apply_subroutines = true;
 
         Collection<Qubit::Qubit> qubits;
         Collection<Qubit_definition::Qubit_definition> qubit_defs;

--- a/include/ast_builder/context.h
+++ b/include/ast_builder/context.h
@@ -8,6 +8,7 @@
 #include <qubit_defs.h>
 #include <discard_qubit_defs.h>
 #include <discard_qubit_def.h>
+#include <arg.h>
 #include <compound_stmt.h>
 #include <gate.h>
 
@@ -35,6 +36,10 @@ namespace Context {
 				return current_block_owner;
 			}
 
+			std::shared_ptr<Gate> get_current_gate() {
+				return current_gate;
+			}
+
             void set_can_apply_subroutines(bool flag = true);
 
             size_t get_max_defined_qubits();
@@ -51,6 +56,8 @@ namespace Context {
 
 			std::shared_ptr<Qubit::Qubit> get_current_qubit();
 
+			std::shared_ptr<Arg::Arg> get_current_arg(const std::string& str, const U64& hash);
+
 			std::shared_ptr<Integer> get_current_qubit_index();
 
 			std::shared_ptr<Variable> get_current_qubit_name();
@@ -63,7 +70,7 @@ namespace Context {
 
 			std::shared_ptr<Variable> get_current_qubit_definition_name();
 
-			std::shared_ptr<Gate> get_current_gate(const std::string& str, int num_qubits, int num_params);
+			std::shared_ptr<Gate> make_current_gate(const std::string& str, int num_qubits, int num_params);
 
 			std::shared_ptr<Discard_qubit_defs> discard_qubit_defs(const std::string& str, const U64& hash, int num_owned_qubit_defs);
 
@@ -74,6 +81,10 @@ namespace Context {
 			int get_current_gate_num_params();
 
 			int get_current_gate_num_qubits();
+			
+			int get_current_applied_block_qubit_def_size() const {
+				return current_applied_block_qubit_def_size;
+			}
 		
 			bool current_block_is_subroutine(){
                 return (subroutines_node != nullptr) && (subroutines_node->build_state() == NB_BUILD);
@@ -81,6 +92,12 @@ namespace Context {
 
 			void set_subroutines_node(std::shared_ptr<Node> _node){
 				subroutines_node = _node;
+			}
+
+			void set_current_applied_block();
+
+			std::shared_ptr<Block> get_current_applied_block() const {
+				return current_applied_block;
 			}
 
 			void render_qig();
@@ -96,13 +113,15 @@ namespace Context {
 			Variable dummy_var;
 
             int subroutine_counter = 0;
-            
+            int current_applied_block_qubit_def_size = 0;
+
             std::shared_ptr<Graph> qig = nullptr;
             fs::path circuit_dir;
 			
 			std::shared_ptr<Qubit_definition::Qubit_definition> current_qubit_definition;
 			std::shared_ptr<Qubit::Qubit> current_qubit;
 			std::shared_ptr<Gate> current_gate;
+			std::shared_ptr<Block> current_applied_block;
 			std::shared_ptr<Node> subroutines_node = nullptr;
 
 	        size_t compound_stmt_depth = Common::COMPOUND_STMT_DEPTH;

--- a/include/ast_builder/context.h
+++ b/include/ast_builder/context.h
@@ -35,7 +35,7 @@ namespace Context {
 				return current_block_owner;
 			}
 
-            void set_can_apply_subroutines();
+            void set_can_apply_subroutines(bool flag = true);
 
             size_t get_max_defined_qubits();
 

--- a/include/run.h
+++ b/include/run.h
@@ -73,7 +73,7 @@ class Run{
             for(auto& entry : fs::directory_iterator(output_dir)){
 
                 // check for directories to avoid running the results.txt file
-                if(entry.is_directory()){
+                if(entry.is_directory() && entry.path().filename() != "interesting_circuits"){
 
                     current++;
 

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -114,7 +114,7 @@ namespace Common {
         main_circuit_name = 15359974437464362266ULL,
 
         body = 14793735007222968981ULL,
-        qreg_name = 10722739978486866664ULL,
+        qubit_def_name = 9637820166840754028ULL,
         qreg_size = 11502232252882731618ULL,
         qubit = 9613145697666387222ULL,
         qubit_op = 7363837753828900628ULL,

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -157,6 +157,8 @@ namespace Common {
         comptime_block = 13310967149289622197ULL,
         comptime_block_def = 5962160394468879029ULL,
         non_comptime_block = 15717574089437842153ULL,
+        arg_singular_qubit = 18441410415153523ULL,
+        arg_register_qubits = 3829129026513754988ULL,
         
         simple_stmt = 15680233693926857886ULL,
         simple_stmts = 7071648921283339959ULL,
@@ -172,6 +174,8 @@ namespace Common {
         dedent = 2224769550356995471ULL,
 
         if_stmt = 5300980200188049869ULL,
+        arguments = 16442092644301152671ULL,
+        arg = 16669728881526232807ULL,
         else_stmt = 2582766405432659795ULL,
         elif_stmt = 9453565397799917274ULL,
         disjunction = 13554539731759707019ULL,

--- a/include/utils/utils.h
+++ b/include/utils/utils.h
@@ -154,8 +154,9 @@ namespace Common {
         discard_internal_qubit = 1018654204566407765ULL,
         discard_single_qubit = 11775807085076373088ULL,
         discard_qreg = 13047647025597388553ULL,
-        decorators = 741076755586776343ULL,
-        
+        comptime_block = 13310967149289622197ULL,
+        comptime_block_def = 5962160394468879029ULL,
+        non_comptime_block = 15717574089437842153ULL,
         
         simple_stmt = 15680233693926857886ULL,
         simple_stmts = 7071648921283339959ULL,

--- a/src/ast_builder/ast.cpp
+++ b/src/ast_builder/ast.cpp
@@ -141,7 +141,7 @@ std::shared_ptr<Node> Ast::get_node_from_term(const std::shared_ptr<Node> parent
 		case Common::qreg_size:
 			return context.get_current_qubit_definition_size();
 
-		case Common::qreg_name:
+		case Common::qubit_def_name:
 			return context.get_current_qubit_definition_name();
 
 		case Common::qubit_def_external: case Common::qubit_def_internal:

--- a/src/ast_builder/ast.cpp
+++ b/src/ast_builder/ast.cpp
@@ -47,9 +47,14 @@ std::shared_ptr<Node> Ast::get_node_from_term(const std::shared_ptr<Node> parent
 
 			return dummy;
 
-		case Common::block: case Common::main_block:
-			context.reset(Context::BLOCK);
-			return context.setup_block(str, hash);
+			case Common::block: case Common::main_block: {
+				context.reset(Context::BLOCK);
+				return context.setup_block(str, hash);
+			}
+
+			case Common::non_comptime_block:
+				context.set_can_apply_subroutines(false);
+				return std::make_shared<Node>(str, hash);
 
 		case Common::body:
 			return std::make_shared<Node>(str, hash);
@@ -160,13 +165,19 @@ std::shared_ptr<Node> Ast::get_node_from_term(const std::shared_ptr<Node> parent
 		case Common::number:
 			return std::make_shared<Integer>();
 
-		case Common::h: case Common::x: case Common::y: case Common::z: {
+		case Common::h: case Common::x: case Common::y: case Common::z: case Common::t:
+			case Common::tdg: case Common::s: case Common::sdg:{
 			return context.get_current_gate(str, 1, 0);
 		}
 
-		case Common::cx : case Common::cy: case Common::cz: case Common::cnot: {
-			return context.get_current_gate(str, 2, 0);
-		}
+			case Common::cx : case Common::cy: case Common::cz: case Common::cnot:
+			case Common::ch: {
+				return context.get_current_gate(str, 2, 0);
+			}
+
+			case Common::crz: {
+				return context.get_current_gate(str, 2, 1);
+			}
 
 		case Common::ccx: case Common::cswap: case Common::toffoli:{
 			return context.get_current_gate(str, 3, 0);

--- a/src/ast_builder/block.cpp
+++ b/src/ast_builder/block.cpp
@@ -115,10 +115,30 @@ std::shared_ptr<Qubit_definition::Qubit_definition> Block::get_next_qubit_def(){
 
     }
 }
+
 std::shared_ptr<Qubit_definition::Qubit_definition> Block::get_next_owned_qubit_def(){
     // Keep iterating maybe_def until we reach the end or find an owned/internal qubit def
     auto maybe_def = qubit_defs.at(qubit_def_pointer);
     while(maybe_def != nullptr && maybe_def->is_external()){
+        maybe_def = qubit_defs.at(++qubit_def_pointer);
+    }
+
+    qubit_def_pointer++;
+
+    if(maybe_def == nullptr){
+        return std::make_shared<Qubit_definition::Qubit_definition>(dummy_def);
+            
+    } else {
+        
+        return std::make_shared<Qubit_definition::Qubit_definition>(*maybe_def); 
+
+    }
+}
+
+std::shared_ptr<Qubit_definition::Qubit_definition> Block::get_next_external_qubit_def(){
+    // Keep iterating maybe_def until we reach the end or find an external qubit def
+    auto maybe_def = qubit_defs.at(qubit_def_pointer);
+    while(maybe_def != nullptr && !maybe_def->is_external()){
         maybe_def = qubit_defs.at(++qubit_def_pointer);
     }
 

--- a/src/ast_builder/block.cpp
+++ b/src/ast_builder/block.cpp
@@ -34,7 +34,7 @@ size_t Block::make_singular_qubit_definition(bool external){
 
 
 size_t Block::make_qubit_definitions(bool external){
-    int type_choice = 0; // random_int(1);
+    int type_choice = random_int(1);
 
     #ifdef DEBUG
     INFO("Creating qubit definitions");
@@ -53,7 +53,7 @@ size_t Block::make_qubit_definitions(bool external){
             target_num_qubits -= make_register_qubit_definition(target_num_qubits, external);
         }
 
-        // type_choice = random_int(1);
+        type_choice = random_int(1);
     }
 
     return (external ? qubit_defs.get_num_external() : qubit_defs.get_num_internal());

--- a/src/ast_builder/context.cpp
+++ b/src/ast_builder/context.cpp
@@ -133,7 +133,7 @@ namespace Context {
         if(current_gate != nullptr){
             std::shared_ptr<Qubit_definition::Qubit_definition> qubit_def = current_applied_block->get_next_external_qubit_def();
             Arg::Type arg_qubit_def_type = qubit_def->get_type() == Qubit_definition::Type::SINGULAR_EXTERNAL ? Arg::Type::SINGULAR : Arg::Type::REGISTER;
-            current_applied_block_qubit_def_size = std::stoi(qubit_def->get_size()->get_string());
+            current_applied_block_qubit_def_size = (arg_qubit_def_type == Arg::Type::SINGULAR) ? 1 : std::stoi(qubit_def->get_size()->get_string());
             return std::make_shared<Arg::Arg>(str, hash, arg_qubit_def_type);
         } else {
             WARNING("Current gate not set but trying to get arg! Using dummy instead");

--- a/src/ast_builder/context.cpp
+++ b/src/ast_builder/context.cpp
@@ -129,6 +129,18 @@ namespace Context {
         return nullptr;
     }
 
+    std::shared_ptr<Arg::Arg> Context::get_current_arg(const std::string& str, const U64& hash){
+        if(current_gate != nullptr){
+            std::shared_ptr<Qubit_definition::Qubit_definition> qubit_def = current_applied_block->get_next_external_qubit_def();
+            Arg::Type arg_qubit_def_type = qubit_def->get_type() == Qubit_definition::Type::SINGULAR_EXTERNAL ? Arg::Type::SINGULAR : Arg::Type::REGISTER;
+            current_applied_block_qubit_def_size = std::stoi(qubit_def->get_size()->get_string());
+            return std::make_shared<Arg::Arg>(str, hash, arg_qubit_def_type);
+        } else {
+            WARNING("Current gate not set but trying to get arg! Using dummy instead");
+            return std::make_shared<Arg::Arg>();
+        }
+    }
+
     std::shared_ptr<Qubit::Qubit> Context::get_current_qubit(){
         if(current_gate == nullptr) {
             current_qubit = get_current_block()->get_random_qubit(std::nullopt);        
@@ -185,7 +197,7 @@ namespace Context {
         }
     }
 
-    std::shared_ptr<Gate> Context::get_current_gate(const std::string& str, int num_qubits, int num_params){
+    std::shared_ptr<Gate> Context::make_current_gate(const std::string& str, int num_qubits, int num_params) {
         current_gate = std::make_shared<Gate>(str, num_qubits, num_params, qig);
         return current_gate;
     }
@@ -218,6 +230,13 @@ namespace Context {
         } else {
             WARNING("Current gate not set but trying to get num params! Assumed 1 qubit");
             return 1;
+        }
+    }
+
+    void Context::set_current_applied_block(){
+        current_applied_block = get_block(current_gate->get_string());
+        if(current_applied_block == nullptr){
+            ERROR("Current applied block not set! Assumed current gate is function");
         }
     }
 

--- a/src/ast_builder/context.cpp
+++ b/src/ast_builder/context.cpp
@@ -18,21 +18,28 @@ namespace Context {
         }
     }
 
-    void Context::set_can_apply_subroutines(){
+    void Context::set_can_apply_subroutines(bool override_flag){
         std::shared_ptr<Block> current_block = get_current_block();
 
-        for(std::shared_ptr<Block> block : blocks){
-            if(!block->owned_by(Common::TOP_LEVEL_CIRCUIT_NAME) &&
-               !block->owned_by(current_block_owner) &&
-                (block->num_external_qubits() <= current_block->total_num_qubits())
-            )
-            {
-                #ifdef DEBUG
-                INFO("Block " + current_block_owner + " can apply subroutines");
-                #endif
-                current_block->set_can_apply_subroutines(true);
+        if (current_block->get_can_apply_subroutines() && override_flag) {
+            for(std::shared_ptr<Block> block : blocks){
+                if (!block->owned_by(Common::TOP_LEVEL_CIRCUIT_NAME) &&
+                    !block->owned_by(current_block_owner) &&
+                    (block->num_external_qubits() <= current_block->total_num_qubits())
+                )
+                {
+                    #ifdef DEBUG
+                    INFO("Block " + current_block_owner + " can apply subroutines");
+                    #endif
+                    return;
+                }
             }
         }
+
+        #ifdef DEBUG
+        INFO("Block " + current_block_owner + " can't apply subroutines");
+        #endif
+        current_block->set_can_apply_subroutines(false);
     }
 
     size_t Context::get_max_defined_qubits(){


### PR DESCRIPTION
This pull request mainly addressed the invalid subroutine calls in guppy, which is now solved by introducing new `arguments.h` and `arg.h` terms which are meant to capture more broadly python function arguments. Currently, they only take in `register_qubits` and `singular_qubits`, but can be easily expanded upon for integers, floats etc. Guppylang is also set to be on the latest release on the main branch reflected in the Dockerfile.

Missing single qubit def is also added to pytket, with minor changes to backend used to run pytket circuits and testing functions for cleaner and more reliable outputs.

One observation is that the naming of functions in context.h are confusing, since the get_..... functions do not fetch any existing data, but creates new instances and passes it back, leading to some possible confusing and conflicts with functions that actually aims to fetch existing private data available in the context.

Also merged main branch changes.