### PR TITLE
stop generating unused classicals in qasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ and tries to sync everything to match the lockfile. As a result, it reinstalls t
 | Pytket | [optimiser](https://github.com/Quantinuum/tket/issues/2109) | fixed |
 | Pytket | [optimiser](https://github.com/Quantinuum/tket2/issues/1417) | ack |
 | CUDA-Q | [parser](https://github.com/NVIDIA/cuda-quantum/issues/4562) | ack |
-| CUDA-Q | [parser](https://github.com/NVIDIA/cuda-quantum/issues/4600) |  |
+| CUDA-Q | [parser](https://github.com/NVIDIA/cuda-quantum/issues/4600) | ack |
 | Qiskit | [basis translator](https://github.com/Qiskit/qiskit/issues/16251) | ack, duplicate |
 | Pytket | [parser](https://github.com/Quantinuum/tket/issues/2179) | ack |
 | Pytket | [routing pass](https://github.com/Quantinuum/tket/issues/2180) | ack |
+| Guppy  | [compiler](https://github.com/Quantinuum/tket2/issues/1632) |  | 
 
 ## Acknowledgements
 

--- a/diff_testing/guppy.py
+++ b/diff_testing/guppy.py
@@ -25,11 +25,8 @@ class guppyTesting(Base):
         tk2_circuit = Tk2Circuit.from_bytes(
             self.hugr_envelope, function_name=f"__main__.{self.circuit_name}"
         )
-        print("before normalize:", tk2_circuit.to_tket1_json())
 
         tk2_circuit = normalize_guppy(tk2_circuit)
-
-        print("after normalize:", tk2_circuit.to_tket1_json())
 
         if opt_level == 1:
             opt_circ, _ = greedy_depth_reduce(tk2_circuit)

--- a/diff_testing/qasm.py
+++ b/diff_testing/qasm.py
@@ -1,4 +1,3 @@
-import re
 from typing import Any, Dict, List
 
 import pennylane as qml
@@ -21,6 +20,7 @@ def _pennylane_conv(qasm_str: str):
         return qml.counts()
 
     return qml.QNode(wrapper, dev)
+
 
 class qasmTesting(Base):
     def __init__(self, circuit, circuit_id: int) -> None:

--- a/diff_testing/qasm.py
+++ b/diff_testing/qasm.py
@@ -1,3 +1,4 @@
+import re
 from typing import Any, Dict, List
 
 import pennylane as qml
@@ -22,14 +23,33 @@ def _pennylane_conv(qasm_str: str):
     return qml.QNode(wrapper, dev)
 
 
+def _strip_unused_cregs(qasm_str: str) -> str:
+    """
+    remove creg declarations that are never assigned to (measure ... -> creg),
+    so qiskit doesn't pad result keys with their zero bits.
+    """
+    # Find all cregs that appear on the RHS of a measure statement
+    used_cregs = set(re.findall(r"measure\s+\S+\s+->\s+(\w+)", qasm_str))
+
+    # Remove creg declarations not in used_cregs
+    def keep_line(line: str) -> bool:
+        m = re.match(r"\s*creg\s+(\w+)\s*\[", line)
+        if m:
+            return m.group(1) in used_cregs
+        return True
+
+    return "\n".join(line for line in qasm_str.splitlines() if keep_line(line))
+
+
 class qasmTesting(Base):
     def __init__(self, circuit, circuit_id: int) -> None:
         super().__init__(circuit, "qasm", circuit_id)
+        self.qasm_str = _strip_unused_cregs(circuit)
         self._testers: List[Base] = [
-            qiskitTesting(qiskit.qasm2.loads(circuit), circuit_id),
-            pytketTesting(pytket.qasm.qasm.circuit_from_qasm_str(circuit), circuit_id),
-            cirqTesting(circuit_from_qasm(circuit), circuit_id, from_qasm=True),
-            # pennylaneTesting(_pennylane_conv(circuit), circuit_id), # TODO: hangs
+            qiskitTesting(qiskit.qasm2.loads(self.qasm_str), circuit_id),
+            pytketTesting(pytket.qasm.qasm.circuit_from_qasm_str(self.qasm_str), circuit_id),
+            cirqTesting(circuit_from_qasm(self.qasm_str), circuit_id, from_qasm=True),
+            # pennylaneTesting(_pennylane_conv(self.qasm_str), circuit_id), # TODO: hangs
         ]
 
     def _get_counts(self, opt_level) -> Dict[Any, int]:

--- a/diff_testing/qasm.py
+++ b/diff_testing/qasm.py
@@ -22,29 +22,10 @@ def _pennylane_conv(qasm_str: str):
 
     return qml.QNode(wrapper, dev)
 
-
-def _strip_unused_cregs(qasm_str: str) -> str:
-    """
-    remove creg declarations that are never assigned to (measure ... -> creg),
-    so qiskit doesn't pad result keys with their zero bits.
-    """
-    # Find all cregs that appear on the RHS of a measure statement
-    used_cregs = set(re.findall(r"measure\s+\S+\s+->\s+(\w+)", qasm_str))
-
-    # Remove creg declarations not in used_cregs
-    def keep_line(line: str) -> bool:
-        m = re.match(r"\s*creg\s+(\w+)\s*\[", line)
-        if m:
-            return m.group(1) in used_cregs
-        return True
-
-    return "\n".join(line for line in qasm_str.splitlines() if keep_line(line))
-
-
 class qasmTesting(Base):
     def __init__(self, circuit, circuit_id: int) -> None:
         super().__init__(circuit, "qasm", circuit_id)
-        self.qasm_str = _strip_unused_cregs(circuit)
+        self.qasm_str = circuit
         self._testers: List[Base] = [
             qiskitTesting(qiskit.qasm2.loads(self.qasm_str), circuit_id),
             pytketTesting(pytket.qasm.qasm.circuit_from_qasm_str(self.qasm_str), circuit_id),

--- a/templates/pytket.qf
+++ b/templates/pytket.qf
@@ -224,6 +224,6 @@ compiler_call =
 
 opt_ks_test = "pt.opt_ks_test()";
 
-opt_statevector_test = "pt.opt_statevector_test(" GET_CIRCUIT_NAME ")";
+opt_statevector_test = "pt.opt_statevector_test()";
 
 # pass_statevector_test = "pt.pytket_pass_test("GET_CIRCUIT_NAME")";

--- a/templates/qasm2.qf
+++ b/templates/qasm2.qf
@@ -73,7 +73,10 @@ measures =
 
 subroutine_defs = (sub_circuit NL)[UNIFORM(1, 3)];
 
-circuit = INTERNAL::qubit_defs INTERNAL::bit_defs NL[2] body;
+# remove internal bit defs as control flow is not used
+# circuit = INTERNAL::qubit_defs INTERNAL::bit_defs NL[2] body;
+
+circuit = INTERNAL::qubit_defs NL[2] body;
 
 body = compound_stmts;
 


### PR DESCRIPTION
- control flow not used so not needed
- qiskit appends unused bits which makes comparison with cirq and pytket wrong
- 